### PR TITLE
Adding [serde(rename_all = "camelCase")] to structs

### DIFF
--- a/src/msg/attachment.rs
+++ b/src/msg/attachment.rs
@@ -20,6 +20,7 @@ error_chain! {
 // == Structs ==
 /// This struct represents an attachment.
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct Attachment {
 
     /// Holds the filename of an attachment.
@@ -29,6 +30,7 @@ pub struct Attachment {
     pub content_type: ContentType,
 
     /// Holds the data of the attachment.
+    #[serde(skip_serializing)]
     pub body_raw: Vec<u8>,
 }
 

--- a/src/msg/envelope.rs
+++ b/src/msg/envelope.rs
@@ -53,6 +53,7 @@ error_chain! {
 /// [Envelope struct]: https://docs.rs/imap-proto/0.14.3/imap_proto/types/struct.Envelope.html
 /// [imap_proto]: https://docs.rs/imap-proto/0.14.3/imap_proto/index.html
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct Envelope {
     // -- Must-Fields --
     // These fields are the mininum needed to send a msg.

--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -71,6 +71,7 @@ error_chain::error_chain! {
 /// This struct represents a whole msg with its attachments, body-content
 /// and its envelope.
 #[derive(Debug, Serialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Msg {
     /// All added attachments are listed in this vector.
     pub attachments: Vec<Attachment>,
@@ -98,6 +99,7 @@ pub struct Msg {
     date: Option<String>,
 
     /// The msg but in raw.
+    #[serde(skip_serializing)]
     raw: Vec<u8>,
 }
 


### PR DESCRIPTION
Serde:
  - Skipping `raw` parts
  - Changing names to CamelCase