### PR TITLE
Makeing Ctx struct independent

### DIFF
--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -141,15 +141,19 @@ impl Account {
     /// # Examples
     /// ```rust
     /// use himalaya::config::model::Account;
+    /// use himalaya::ctx::Ctx;
     ///
     /// fn main() {
     ///
     ///     // the testing accounts
-    ///     let account_with_custom_signature = Account::new_with_signature(
+    ///     let ctx1 = Ctx {
+    ///         account: Account::new_with_signature(
     ///         Some("Email name"),
     ///         "some@mail.com",
-    ///         Some("Custom signature! :)")
-    ///     );
+    ///         Some("Custom signature! :)"),
+    ///         .. Ctx::default()
+    ///     )
+    ///     };
     ///
     ///     let account_with_default_signature = Account::new_with_signature(
     ///         Some("Email name"),

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -5,23 +5,26 @@ use crate::{
     output::model::Output,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Ctx<'a> {
-    pub config: &'a Config,
-    pub account: &'a Account,
-    pub output: &'a Output,
-    pub mbox: &'a str,
-    pub arg_matches: &'a clap::ArgMatches<'a>,
+    pub config: Config,
+    pub account: Account,
+    pub output: Output,
+    pub mbox: String,
+    pub arg_matches: clap::ArgMatches<'a>,
 }
 
 impl<'a> Ctx<'a> {
-    pub fn new(
-        config: &'a Config,
-        account: &'a Account,
-        output: &'a Output,
-        mbox: &'a str,
-        arg_matches: &'a clap::ArgMatches<'a>,
+    pub fn new<S: ToString>(
+        config: Config,
+        account: Account,
+        output: Output,
+        mbox: S,
+        arg_matches: clap::ArgMatches<'a>,
     ) -> Self {
+
+        let mbox = mbox.to_string();
+
         Self {
             config,
             account,

--- a/src/flag/cli.rs
+++ b/src/flag/cli.rs
@@ -53,7 +53,7 @@ pub fn matches(ctx: &Ctx) -> Result<bool> {
         debug!("flags: {}", flags);
 
         let mut imap_conn = ImapConnector::new(&ctx.account)?;
-        imap_conn.set_flags(ctx.mbox, uid, flags)?;
+        imap_conn.set_flags(&ctx.mbox, uid, flags)?;
 
         imap_conn.logout();
         return Ok(true);
@@ -69,7 +69,7 @@ pub fn matches(ctx: &Ctx) -> Result<bool> {
         debug!("flags: {}", flags);
 
         let mut imap_conn = ImapConnector::new(&ctx.account)?;
-        imap_conn.add_flags(ctx.mbox, uid, flags)?;
+        imap_conn.add_flags(&ctx.mbox, uid, flags)?;
 
         imap_conn.logout();
         return Ok(true);
@@ -85,7 +85,7 @@ pub fn matches(ctx: &Ctx) -> Result<bool> {
         debug!("flags: {}", flags);
 
         let mut imap_conn = ImapConnector::new(&ctx.account)?;
-        imap_conn.remove_flags(ctx.mbox, uid, flags)?;
+        imap_conn.remove_flags(&ctx.mbox, uid, flags)?;
 
         imap_conn.logout();
         return Ok(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,13 +50,15 @@ fn run() -> Result<()> {
     );
 
     let raw_args: Vec<String> = env::args().collect();
+
+    // This is used if you click on a mailaddress in the webbrowser
     if raw_args.len() > 1 && raw_args[1].starts_with("mailto:") {
         let config = Config::new(None)?;
-        let account = config.find_account_by_name(None)?;
+        let account = config.find_account_by_name(None)?.clone();
         let output = Output::new("plain");
         let mbox = "INBOX";
         let arg_matches = ArgMatches::default();
-        let app = Ctx::new(&config, &account, &output, &mbox, &arg_matches);
+        let app = Ctx::new(config, account, output, mbox, arg_matches);
         let url = Url::parse(&raw_args[1])?;
         return Ok(msg_matches_mailto(&app, &url)?);
     }
@@ -80,14 +82,15 @@ fn run() -> Result<()> {
 
     let account_name = arg_matches.value_of("account");
     debug!("init account: {}", account_name.unwrap_or("default"));
-    let account = config.find_account_by_name(account_name)?;
+    let account = config.find_account_by_name(account_name)?.clone();
     trace!("account: {:?}", account);
 
-    let mbox = arg_matches.value_of("mailbox").unwrap();
+    let mbox = arg_matches.value_of("mailbox").unwrap().to_string();
     debug!("mailbox: {}", mbox);
 
     debug!("begin matching");
-    let app = Ctx::new(&config, &account, &output, &mbox, &arg_matches);
+
+    let app = Ctx::new(config, account, output, mbox, arg_matches);
     let _matched = mbox::cli::matches(&app)?
         || flag::cli::matches(&app)?
         || imap::cli::matches(&app)?

--- a/src/msg/cli.rs
+++ b/src/msg/cli.rs
@@ -492,7 +492,7 @@ pub fn msg_matches_mailto(ctx: &Ctx, url: &Url) -> Result<()> {
     }
 
     let envelope = Envelope {
-        from: vec![ctx.config.address(ctx.account)],
+        from: vec![ctx.config.address(&ctx.account)],
         to: vec![url.path().to_string()],
         encoding: ContentTransferEncoding::Base64,
         bcc: Some(bcc),

--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -167,7 +167,7 @@ impl Msg {
         }
 
         if let None = envelope.signature {
-            envelope.signature = ctx.config.signature(ctx.account);
+            envelope.signature = ctx.config.signature(&ctx.account);
         }
 
         let body = Body::from(if let Some(sig) = envelope.signature.as_ref() {
@@ -337,7 +337,7 @@ impl Msg {
 
         self.envelope = Envelope {
             subject: Some(format!("Fwd: {}", old_subject)),
-            sender: Some(ctx.config.address(ctx.account)),
+            sender: Some(ctx.config.address(&ctx.account)),
             // and use the rest of the headers
             ..self.envelope.clone()
         };


### PR DESCRIPTION
- The Ctx struct doesn't include references anymore. This makes it easier to
    create new Ctx instances by doing the following:

        Ctx {
            <attribute>: <value>,
            .. Ctx::default()
        }

    This helps especially for writing tests.

Also the attributes of the Ctx struct in the main-entry function aren't used
anymore after creating the Ctx struct. So there's no need to have only
references in the Ctx struct.

The tests aren't working yet, but I'd do this in an other PR.