### PR TITLE
Formatting fixes and refactoring

### DIFF
--- a/src/flag/model.rs
+++ b/src/flag/model.rs
@@ -88,8 +88,8 @@ impl ToString for Flags {
             }
         }
 
-        // remove the trailing whitespace
-        flags.pop();
+        // remove the trailing whitespaces
+        flags = flags.trim_end_matches(' ').to_string();
         flags
     }
 }
@@ -233,12 +233,16 @@ mod tests {
         // since we can't influence the order in the HashSet, we're gonna convert it into a vec,
         // sort it according to the names and compare it aftwards.
         let flag_string = flags.to_string();
-        let mut flag_vec: Vec<String> = flag_string.split_ascii_whitespace()
+        let mut flag_vec: Vec<String> = flag_string
+            .split_ascii_whitespace()
             .map(|word| word.to_string())
             .collect();
         flag_vec.sort();
 
-        assert_eq!(flag_vec, vec!["\\Answered".to_string(), "\\Seen".to_string()]);
+        assert_eq!(
+            flag_vec,
+            vec!["\\Answered".to_string(), "\\Seen".to_string()]
+        );
     }
 
     #[test]

--- a/src/imap/model.rs
+++ b/src/imap/model.rs
@@ -18,7 +18,7 @@ error_chain! {
 
 /// A little helper function to create a similiar error output. (to avoid duplicated code)
 fn format_err_msg(description: &str, account: &Account) -> String {
-    format!("{}. Given Account: {#:?}", description, account)
+    format!("{}. Given Account: {:#?}", description, account)
 }
 
 /// The main struct to create a connection to your imap-server.

--- a/src/mbox/model.rs
+++ b/src/mbox/model.rs
@@ -61,7 +61,7 @@ impl ToString for Attributes {
         }
 
         // remove the trailing whitespace with the comma
-        attributes.pop();
+        attributes = attributes.trim_end_matches(' ').to_string();
         attributes.pop();
 
         attributes

--- a/tests/imap_test.rs
+++ b/tests/imap_test.rs
@@ -74,7 +74,7 @@ fn msg() {
                 "INBOX",
                 &msg.get_uid().unwrap().to_string(),
                 Flags::from(vec![Flag::Deleted]),
-                )
+            )
             .unwrap();
     }
     imap_conn.expunge("INBOX").unwrap();
@@ -130,13 +130,13 @@ fn msg() {
     assert_eq!(
         msg_a.headers.subject.clone().unwrap_or_default(),
         "Subject A"
-        );
+    );
     assert_eq!(&msg_a.headers.from[0], "sender-a@localhost");
 
     assert_eq!(
         msg_b.headers.subject.clone().unwrap_or_default(),
         "Subject B"
-        );
+    );
     assert_eq!(&msg_b.headers.from[0], "Sender B <sender-b@localhost>");
 
     // TODO: search messages


### PR DESCRIPTION
- Using `trim_end_matches` instead of "pop"s now.
- Executed `cargo fmt`

@soywod