### PR TITLE
Fixing output for template-building

### DIFF
--- a/src/msg/model.rs
+++ b/src/msg/model.rs
@@ -95,7 +95,7 @@ impl From<&Msg> for MsgSerialized {
 
 impl fmt::Display for MsgSerialized {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{}", self.msg.body)
+        write!(formatter, "{}", self.msg)
     }
 }
 


### PR DESCRIPTION
Is it fine that I just use the `Display` trait implementation of `Msg`?